### PR TITLE
Feature (Tarea #2): Agregar Summary, Matriz de Confusión y F1 Score

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,3 +1,4 @@
 # Contributors
 
 - Tomás Macrade
+- Nahuel Nicolás Alvarez

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,6 +1,7 @@
 # Contributors
 
 - Claudio Gabriel Alonso
+- Fernanda Alcaraz
 - Joaquín Palacio Feijóo
 - Nahuel Nicolas Alvarez
 - Tomás Macrade

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,5 +1,6 @@
 # Contributors
 
+- Claudio Gabriel Alonso
 - Joaquín Palacio Feijóo
 - Nahuel Nicolas Alvarez
 - Tomás Macrade

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,4 +1,6 @@
 # Contributors
 
+- Joaquín Palacio Feijóo
+- Nahuel Nicolas Alvarez
 - Tomás Macrade
-- Nahuel Nicolás Alvarez
+- WhiteBoxML Contributors

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -3,4 +3,3 @@
 - Joaquín Palacio Feijóo
 - Nahuel Nicolas Alvarez
 - Tomás Macrade
-- WhiteBoxML Contributors

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -141,6 +141,66 @@ def test_recall_macro_and_weighted_and_none():
     assert np.allclose(arr, per_class)
 
 
+def test_f1_binary_basic():
+    """
+    Test F1 básico en binario
+    :authors: Nahuel Nicolas Alvarez
+    :date: 21/04/2026
+    """
+
+    y_true = [1, 0, 1, 1]
+    y_pred = [1, 0, 0, 1]
+    assert metricas.f1_score(
+        y_true, y_pred, average="binary", pos_label=1
+    ) == pytest.approx(0.8)
+
+
+def test_f1_binary_no_tp():
+    """
+    Test F1 sin verdaderos positivos
+    :authors: Nahuel Nicolas Alvarez
+    :date: 21/04/2026
+    """
+
+    y_true = [1, 1, 1]
+    y_pred = [0, 0, 0]
+    assert metricas.f1_score(y_true, y_pred, average="binary", pos_label=1) == 0.0
+
+
+def test_f1_micro_equals_accuracy():
+    """
+    Test F1 micro vs accuracy
+    :authors: Nahuel Nicolas Alvarez
+    :date: 21/04/2026
+    """
+
+    y_true = [0, 1, 2, 2]
+    y_pred = [0, 2, 2, 1]
+    expected = float(np.mean(np.array(y_true) == np.array(y_pred)))
+    assert metricas.f1_score(y_true, y_pred, average="micro") == pytest.approx(expected)
+
+
+def test_f1_macro_weighted_and_none():
+    """
+    Test F1 con distintos average
+    :authors: Nahuel Nicolas Alvarez
+    :date: 21/04/2026
+    """
+
+    y_true = [0, 1, 2, 0]
+    y_pred = [0, 2, 1, 0]
+    per_class = np.array([1.0, 0.0, 0.0])
+
+    assert metricas.f1_score(y_true, y_pred, average="macro") == pytest.approx(
+        np.mean(per_class)
+    )
+    assert metricas.f1_score(y_true, y_pred, average="weighted") == pytest.approx(0.5)
+    arr = metricas.f1_score(y_true, y_pred, average=None)
+    assert isinstance(arr, np.ndarray)
+    assert arr.shape == (3,)
+    assert np.allclose(arr, per_class)
+
+
 def test_mean_squared_error():
     """
     Test MSE

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -23,6 +23,7 @@ def test_report_classification_perfect():
             "Accuracy": [1.0],
             "Precision": [1.0],
             "Recall": [1.0],
+            "F1": [1.0],
         }
     )
 
@@ -69,6 +70,7 @@ def test_report_classification_imperfect():
             "Accuracy": [0.5],
             "Precision": [1 / 3],
             "Recall": [1.0],
+            "F1": [0.5],
         }
     )
 
@@ -115,6 +117,7 @@ def test_report_classification_macro():
             "Accuracy": [0.5],
             "Precision": [2 / 3],
             "Recall": [2 / 3],
+            "F1": [0.5],
         }
     )
 
@@ -138,6 +141,7 @@ def test_report_classification_micro():
             "Accuracy": [0.5],
             "Precision": [0.5],
             "Recall": [0.5],
+            "F1": [0.5],
         }
     )
 

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -2,19 +2,20 @@
 Tests del módulo de reportes
 """
 
+import numpy as np
 import pandas as pd
+import pytest
 from pandas.testing import assert_frame_equal
 
 from whiteboxml import reporting
 
 
-def test_report_classification_perfect():
+def test_summary_classification_perfect():
     """
-    Test reporte de clasificación perfecto
+    Test reporte de clasificación binaria con predicción perfecta.
     :authors: Joaquín Palacio Feijóo
-    :date: 15/04/2026
+    :date: 21/04/2026
     """
-
     y_true = [1, 0, 1, 1]
     y_pred = [1, 0, 1, 1]
 
@@ -26,41 +27,17 @@ def test_report_classification_perfect():
         }
     )
 
-    df = reporting.classification_summary(y_true, y_pred)
+    df = reporting.summary(y_true, y_pred)
 
     assert_frame_equal(df, expected_df)
 
 
-def test_report_regression_perfect():
+def test_summary_classification_imperfect():
     """
-    Test reporte de regresión perfecto
+    Test reporte de clasificación binaria con errores.
     :authors: Joaquín Palacio Feijóo
-    :date: 15/04/2026
+    :date: 21/04/2026
     """
-
-    y_true = [1, 0, 1, 1]
-    y_pred = [1, 0, 1, 1]
-
-    expected_df = pd.DataFrame(
-        {
-            "MSE": [0.0],
-            "MAE": [0.0],
-            "R^2": [1.0],
-        }
-    )
-
-    df = reporting.regression_summary(y_true, y_pred)
-
-    assert_frame_equal(df, expected_df)
-
-
-def test_report_classification_imperfect():
-    """
-    Test reporte de clasificación imperfecto
-    :authors: Joaquín Palacio Feijóo
-    :date: 15/04/2026
-    """
-
     y_true = [0, 0, 0, 1]
     y_pred = [1, 0, 1, 1]
 
@@ -72,18 +49,121 @@ def test_report_classification_imperfect():
         }
     )
 
-    df = reporting.classification_summary(y_true, y_pred)
+    df = reporting.summary(y_true, y_pred)
 
     assert_frame_equal(df, expected_df)
 
 
-def test_report_regression_imperfect():
+def test_summary_classification_explicit_mode():
     """
-    Test reporte de regresión imperfecto
+    Test reporte forzando mode='classification'.
     :authors: Joaquín Palacio Feijóo
-    :date: 15/04/2026
+    :date: 21/04/2026
     """
+    y_true = [1, 0, 1, 1]
+    y_pred = [1, 0, 1, 1]
 
+    expected_df = pd.DataFrame(
+        {
+            "Accuracy": [1.0],
+            "Precision": [1.0],
+            "Recall": [1.0],
+        }
+    )
+
+    df = reporting.summary(y_true, y_pred, mode="classification")
+
+    assert_frame_equal(df, expected_df)
+
+
+def test_summary_multiclass_auto():
+    """
+    Test auto-detección de clasificación multiclase (usa average='macro').
+    :authors: Joaquín Palacio Feijóo
+    :date: 21/04/2026
+    """
+    y_true = [0, 0, 1, 1, 2, 2]
+    y_pred = [0, 0, 1, 1, 2, 2]
+
+    expected_df = pd.DataFrame(
+        {
+            "Accuracy": [1.0],
+            "Precision": [1.0],
+            "Recall": [1.0],
+        }
+    )
+
+    df = reporting.summary(y_true, y_pred)
+
+    assert_frame_equal(df, expected_df)
+
+
+def test_summary_multiclass_imperfect():
+    """
+    Test clasificación multiclase imperfecta con average='macro'.
+    :authors: Joaquín Palacio Feijóo
+    :date: 21/04/2026
+    """
+    y_true = [0, 0, 0, 1]
+    y_pred = [1, 0, 1, 1]
+
+    expected_df = pd.DataFrame(
+        {
+            "Accuracy": [0.5],
+            "Precision": [1 / 3],
+            "Recall": [1.0],
+        }
+    )
+
+    df = reporting.summary(y_true, y_pred, mode="classification")
+
+    assert_frame_equal(df, expected_df)
+
+
+def test_summary_regression_perfect():
+    """
+    Test reporte de regresión con predicción perfecta.
+    :authors: Joaquín Palacio Feijóo
+    :date: 21/04/2026
+    """
+    y_true = [1.5, 2.3, 3.7]
+    y_pred = [1.5, 2.3, 3.7]
+
+    expected_df = pd.DataFrame(
+        {
+            "MSE": [0.0],
+            "MAE": [0.0],
+            "R^2": [1.0],
+        }
+    )
+
+    df = reporting.summary(y_true, y_pred)
+
+    assert_frame_equal(df, expected_df)
+
+
+def test_summary_regression_imperfect():
+    """
+    Test reporte de regresión con errores.
+    :authors: Joaquín Palacio Feijóo
+    :date: 21/04/2026
+    """
+    y_true = [1.5, 2.5, 3.5]
+    y_pred = [1.0, 2.0, 3.0]
+
+    df = reporting.summary(y_true, y_pred)
+
+    assert df["MSE"].iloc[0] == pytest.approx(0.25)
+    assert df["MAE"].iloc[0] == pytest.approx(0.5)
+    assert "R^2" in df.columns
+
+
+def test_summary_regression_explicit_mode():
+    """
+    Test reporte forzando mode='regression' con datos enteros.
+    :authors: Joaquín Palacio Feijóo
+    :date: 21/04/2026
+    """
     y_true = [0, 0, 0, 1]
     y_pred = [1, 0, 1, 1]
 
@@ -95,52 +175,62 @@ def test_report_regression_imperfect():
         }
     )
 
-    df = reporting.regression_summary(y_true, y_pred)
+    df = reporting.summary(y_true, y_pred, mode="regression")
 
     assert_frame_equal(df, expected_df)
 
 
-def test_report_classification_macro():
+def test_summary_auto_detects_classification_from_int():
     """
-    Test reporte de clasificación usando average='macro' explícito
+    Test que datos enteros se detectan como clasificación.
     :authors: Joaquín Palacio Feijóo
-    :date: 15/04/2026
+    :date: 21/04/2026
     """
+    y_true = [0, 1, 1, 0]
+    y_pred = [0, 1, 0, 0]
 
-    y_true = [0, 0, 0, 1]
-    y_pred = [1, 0, 1, 1]
+    df = reporting.summary(y_true, y_pred)
 
-    expected_df = pd.DataFrame(
-        {
-            "Accuracy": [0.5],
-            "Precision": [2 / 3],
-            "Recall": [2 / 3],
-        }
-    )
-
-    df = reporting.classification_summary(y_true, y_pred, average="macro")
-
-    assert_frame_equal(df, expected_df)
+    assert "Accuracy" in df.columns
+    assert "Precision" in df.columns
+    assert "Recall" in df.columns
 
 
-def test_report_classification_micro():
+def test_summary_auto_detects_regression_from_float():
     """
-    Test reporte de clasificación usando average='micro' explícito
+    Test que datos float con decimales se detectan como regresión.
     :authors: Joaquín Palacio Feijóo
-    :date: 15/04/2026
+    :date: 21/04/2026
     """
+    y_true = [1.1, 2.2, 3.3]
+    y_pred = [1.0, 2.0, 3.0]
 
-    y_true = [0, 0, 0, 1]
-    y_pred = [1, 0, 1, 1]
+    df = reporting.summary(y_true, y_pred)
 
-    expected_df = pd.DataFrame(
-        {
-            "Accuracy": [0.5],
-            "Precision": [0.5],
-            "Recall": [0.5],
-        }
-    )
+    assert "MSE" in df.columns
+    assert "MAE" in df.columns
+    assert "R^2" in df.columns
 
-    df = reporting.classification_summary(y_true, y_pred, average="micro")
 
-    assert_frame_equal(df, expected_df)
+def test_summary_auto_detects_classification_from_strings():
+    """
+    Test que datos string se detectan como clasificación.
+    :authors: Joaquín Palacio Feijóo
+    :date: 21/04/2026
+    """
+    y_true = np.array(["cat", "dog", "cat", "cat"])
+    y_pred = np.array(["cat", "dog", "dog", "cat"])
+
+    df = reporting.summary(y_true, y_pred)
+
+    assert "Accuracy" in df.columns
+
+
+def test_summary_invalid_mode():
+    """
+    Test que un mode inválido lanza ValueError.
+    :authors: Joaquín Palacio Feijóo
+    :date: 21/04/2026
+    """
+    with pytest.raises(ValueError, match="mode"):
+        reporting.summary([1, 2], [1, 2], mode="invalid")

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -1,0 +1,146 @@
+"""
+Tests del módulo de reportes
+"""
+
+import pandas as pd
+from pandas.testing import assert_frame_equal
+
+from whiteboxml import reporting
+
+
+def test_report_classification_perfect():
+    """
+    Test reporte de clasificación perfecto
+    :authors: Joaquín Palacio Feijóo
+    :date: 15/04/2026
+    """
+
+    y_true = [1, 0, 1, 1]
+    y_pred = [1, 0, 1, 1]
+
+    expected_df = pd.DataFrame(
+        {
+            "Accuracy": [1.0],
+            "Precision": [1.0],
+            "Recall": [1.0],
+        }
+    )
+
+    df = reporting.classification_summary(y_true, y_pred)
+
+    assert_frame_equal(df, expected_df)
+
+
+def test_report_regression_perfect():
+    """
+    Test reporte de regresión perfecto
+    :authors: Joaquín Palacio Feijóo
+    :date: 15/04/2026
+    """
+
+    y_true = [1, 0, 1, 1]
+    y_pred = [1, 0, 1, 1]
+
+    expected_df = pd.DataFrame(
+        {
+            "MSE": [0.0],
+            "MAE": [0.0],
+            "R^2": [1.0],
+        }
+    )
+
+    df = reporting.regression_summary(y_true, y_pred)
+
+    assert_frame_equal(df, expected_df)
+
+
+def test_report_classification_imperfect():
+    """
+    Test reporte de clasificación imperfecto
+    :authors: Joaquín Palacio Feijóo
+    :date: 15/04/2026
+    """
+
+    y_true = [0, 0, 0, 1]
+    y_pred = [1, 0, 1, 1]
+
+    expected_df = pd.DataFrame(
+        {
+            "Accuracy": [0.5],
+            "Precision": [1 / 3],
+            "Recall": [1.0],
+        }
+    )
+
+    df = reporting.classification_summary(y_true, y_pred)
+
+    assert_frame_equal(df, expected_df)
+
+
+def test_report_regression_imperfect():
+    """
+    Test reporte de regresión imperfecto
+    :authors: Joaquín Palacio Feijóo
+    :date: 15/04/2026
+    """
+
+    y_true = [0, 0, 0, 1]
+    y_pred = [1, 0, 1, 1]
+
+    expected_df = pd.DataFrame(
+        {
+            "MSE": [0.5],
+            "MAE": [0.5],
+            "R^2": [-1.6666666666666665],
+        }
+    )
+
+    df = reporting.regression_summary(y_true, y_pred)
+
+    assert_frame_equal(df, expected_df)
+
+
+def test_report_classification_macro():
+    """
+    Test reporte de clasificación usando average='macro' explícito
+    :authors: Joaquín Palacio Feijóo
+    :date: 15/04/2026
+    """
+
+    y_true = [0, 0, 0, 1]
+    y_pred = [1, 0, 1, 1]
+
+    expected_df = pd.DataFrame(
+        {
+            "Accuracy": [0.5],
+            "Precision": [2 / 3],
+            "Recall": [2 / 3],
+        }
+    )
+
+    df = reporting.classification_summary(y_true, y_pred, average="macro")
+
+    assert_frame_equal(df, expected_df)
+
+
+def test_report_classification_micro():
+    """
+    Test reporte de clasificación usando average='micro' explícito
+    :authors: Joaquín Palacio Feijóo
+    :date: 15/04/2026
+    """
+
+    y_true = [0, 0, 0, 1]
+    y_pred = [1, 0, 1, 1]
+
+    expected_df = pd.DataFrame(
+        {
+            "Accuracy": [0.5],
+            "Precision": [0.5],
+            "Recall": [0.5],
+        }
+    )
+
+    df = reporting.classification_summary(y_true, y_pred, average="micro")
+
+    assert_frame_equal(df, expected_df)

--- a/tests/test_reporting_confusion_matrix.py
+++ b/tests/test_reporting_confusion_matrix.py
@@ -1,0 +1,26 @@
+"""
+Tests de matriz de confusión para el módulo de reporting.
+
+:authors: Nahuel Nicolas Alvarez
+:date: 19/04/2026
+"""
+
+import numpy as np
+
+from whiteboxml.reporting.visualizacion.confusion_matrix import confusion_matrix
+
+
+def test_confusion_matrix_binaria_basica():
+    """
+    Test matriz de confusión binaria básica.
+    :authors: Alvarez Nahuel Nicolas
+    :date: 19/04/2026
+    """
+    y_true = [0, 0, 1, 1]
+    y_pred = [0, 1, 0, 1]
+
+    expected = np.array([[1, 1], [1, 1]])
+
+    result = confusion_matrix(y_true, y_pred)
+
+    assert np.array_equal(result, expected)

--- a/tests/test_reporting_confusion_matrix.py
+++ b/tests/test_reporting_confusion_matrix.py
@@ -5,9 +5,17 @@ Tests de matriz de confusión para el módulo de reporting.
 :date: 19/04/2026
 """
 
+import matplotlib
+import matplotlib.pyplot as plt
 import numpy as np
+from matplotlib.colors import to_rgba
 
-from whiteboxml.reporting.visualizacion.confusion_matrix import confusion_matrix
+from whiteboxml.reporting.visualizacion.confusion_matrix import (
+    confusion_matrix,
+    plot_confusion_matrix,
+)
+
+matplotlib.use("Agg")
 
 
 def test_confusion_matrix_binaria_basica():
@@ -24,3 +32,52 @@ def test_confusion_matrix_binaria_basica():
     result = confusion_matrix(y_true, y_pred)
 
     assert np.array_equal(result, expected)
+
+
+def test_plot_confusion_matrix_con_metricas_muestra_tabla():
+    """
+    Testea que el plot con métricas muestre panel lateral con tabla y accuracy.
+
+    :authors: Alvarez Nahuel Nicolas
+    :date: 29/04/2026
+    """
+    cm = np.array([[5, 1, 0], [1, 4, 1], [0, 1, 6]])
+    labels = [0, 1, 2]
+
+    fig, _ = plot_confusion_matrix(cm, labels=labels, show_class_metrics=True)
+
+    assert len(fig.axes) == 3
+
+    metrics_axes = [axis for axis in fig.axes if len(axis.tables) > 0]
+    assert len(metrics_axes) == 1
+
+    metrics_ax = metrics_axes[0]
+    assert "Accuracy:" in metrics_ax.get_title()
+
+    table = metrics_ax.tables[0]
+    assert table[(0, 0)].get_text().get_text() == "Clase"
+    assert table[(0, 0)].get_facecolor() == to_rgba("#1e3a8a")
+    assert table[(0, 0)].get_text().get_color() == "white"
+
+    assert table[(1, 0)].get_facecolor() == to_rgba("#dbeafe")
+    assert table[(2, 0)].get_facecolor() == to_rgba("#eff6ff")
+
+    plt.close(fig)
+
+
+def test_plot_confusion_matrix_sin_metricas_sin_tabla():
+    """
+    Testea que el plot sin métricas no agregue panel lateral.
+
+    :authors: Alvarez Nahuel Nicolas
+    :date: 29/04/2026
+    """
+    cm = np.array([[2, 0], [1, 3]])
+    labels = [0, 1]
+
+    fig, _ = plot_confusion_matrix(cm, labels=labels, show_class_metrics=False)
+
+    assert len(fig.axes) == 2
+    assert all(len(axis.tables) == 0 for axis in fig.axes)
+
+    plt.close(fig)

--- a/tests/test_reporting_roc_pr_curves.py
+++ b/tests/test_reporting_roc_pr_curves.py
@@ -1,0 +1,101 @@
+"""
+Tests del módulo ROC.
+
+:authors: Claudio Gabriel Alonso
+:date: 21/04/2026
+"""
+
+import matplotlib
+import numpy as np
+
+from whiteboxml.reporting.visualizacion.roc_pr_curves import (
+    calculate_auc,
+    calculate_roc_curve,
+    plot_roc_curve,
+)
+
+matplotlib.use("Agg")
+
+
+def test_auc_perfect():
+    """
+    Test AUC perfecto (modelo ideal)
+    :authors: Claudio Gabriel Alonso
+    :date: 21/04/2026
+    """
+
+    fpr = [0.0, 0.0, 1.0]
+    tpr = [0.0, 1.0, 1.0]
+
+    auc = calculate_auc(fpr, tpr)
+
+    assert auc == 1.0
+
+
+def test_auc_random():
+    """
+    Test AUC modelo aleatorio
+    :authors: Claudio Gabriel Alonso
+    :date: 21/04/2026
+    """
+
+    fpr = [0.0, 1.0]
+    tpr = [0.0, 1.0]
+
+    auc = calculate_auc(fpr, tpr)
+
+    assert auc == 0.5
+
+
+def test_roc_curve_basic():
+    """
+    Test básico de la curva ROC
+    :authors: Claudio Gabriel Alonso
+    :date: 21/04/2026
+    """
+
+    y_true = [0, 0, 1, 1]
+    y_pred_proba = [0.1, 0.4, 0.35, 0.8]
+
+    fpr, tpr, thresholds = calculate_roc_curve(y_true, y_pred_proba)
+
+    # Validaciones básicas
+    assert len(fpr) == len(tpr) == len(thresholds)
+    assert fpr[0] == 0.0
+    assert tpr[0] == 0.0
+
+    # Monotonía
+    assert np.all(np.diff(fpr) >= 0)
+    assert np.all(np.diff(tpr) >= 0)
+
+
+def test_roc_curve_perfect():
+    """
+    Test curva ROC perfecta
+    :authors: Claudio Gabriel Alonso
+    :date: 21/04/2026
+    """
+
+    y_true = [0, 0, 1, 1]
+    y_pred_proba = [0.1, 0.2, 0.8, 0.9]
+
+    fpr, tpr, _ = calculate_roc_curve(y_true, y_pred_proba)
+    auc = calculate_auc(fpr, tpr)
+
+    assert auc == 1.0
+
+
+def test_plot_roc_curve_runs():
+    """
+    Test que el plot de ROC se ejecuta sin errores
+    :authors: Claudio Gabriel Alonso
+    :date: 21/04/2026
+    """
+
+    y_true = [0, 1, 0, 1]
+    y_pred_proba = [0.2, 0.8, 0.4, 0.6]
+
+    try:
+        plot_roc_curve(y_true, y_pred_proba)
+    except Exception as e:
+        raise AssertionError(f"El plot falló: {e}") from e

--- a/tests/test_reporting_roc_pr_curves.py
+++ b/tests/test_reporting_roc_pr_curves.py
@@ -1,7 +1,7 @@
 """
-Tests del módulo ROC.
+Tests del módulo ROC y PR.
 
-:authors: Claudio Gabriel Alonso
+:authors: Claudio Gabriel Alonso, Fernanda Alcaraz
 :date: 21/04/2026
 """
 
@@ -10,7 +10,9 @@ import numpy as np
 
 from whiteboxml.reporting.visualizacion.roc_pr_curves import (
     calculate_auc,
+    calculate_precision_recall_curve,
     calculate_roc_curve,
+    plot_pr_curve,
     plot_roc_curve,
 )
 
@@ -96,6 +98,41 @@ def test_plot_roc_curve_runs():
     y_pred_proba = [0.2, 0.8, 0.4, 0.6]
 
     fig, ax = plot_roc_curve(y_true, y_pred_proba, show=False)
+
+    assert fig is not None
+    assert ax is not None
+
+
+def test_pr_curve_basic():
+    """
+    Test básico de la curva PR
+    """
+
+    y_true = [0, 0, 1, 1]
+    y_pred_proba = [0.1, 0.4, 0.35, 0.8]
+
+    recall, precision, thresholds = calculate_precision_recall_curve(
+        y_true,
+        y_pred_proba,
+    )
+
+    assert len(recall) == len(precision)
+    assert len(recall) >= len(thresholds)
+
+
+def test_plot_pr_curve_runs():
+    """
+    Test del plot de PR
+    """
+
+    y_true = [0, 1, 0, 1]
+    y_pred_proba = [0.2, 0.8, 0.4, 0.6]
+
+    fig, ax = plot_pr_curve(
+        y_true,
+        y_pred_proba,
+        show=False,
+    )
 
     assert fig is not None
     assert ax is not None

--- a/tests/test_reporting_roc_pr_curves.py
+++ b/tests/test_reporting_roc_pr_curves.py
@@ -89,13 +89,13 @@ def test_plot_roc_curve_runs():
     """
     Test que el plot de ROC se ejecuta sin errores
     :authors: Claudio Gabriel Alonso
-    :date: 21/04/2026
+    :date: 29/04/2026
     """
 
     y_true = [0, 1, 0, 1]
     y_pred_proba = [0.2, 0.8, 0.4, 0.6]
 
-    try:
-        plot_roc_curve(y_true, y_pred_proba)
-    except Exception as e:
-        raise AssertionError(f"El plot falló: {e}") from e
+    fig, ax = plot_roc_curve(y_true, y_pred_proba, show=False)
+
+    assert fig is not None
+    assert ax is not None

--- a/whiteboxml/metricas/__init__.py
+++ b/whiteboxml/metricas/__init__.py
@@ -5,13 +5,14 @@ Metricas: Conjunto de métricas útiles para clasificación y regresión
 :date: 27/02/2026
 """
 
-from .clasificacion import accuracy, precision, recall
+from .clasificacion import accuracy, f1_score, precision, recall
 from .regresion import mean_absolute_error, mean_squared_error, r2
 
 __all__ = [
     "accuracy",
     "precision",
     "recall",
+    "f1_score",
     "mean_absolute_error",
     "mean_squared_error",
     "r2",

--- a/whiteboxml/metricas/clasificacion/__init__.py
+++ b/whiteboxml/metricas/clasificacion/__init__.py
@@ -5,6 +5,6 @@ Clasificación: Conjunto de métricas para clasificación
 :date: 27/02/2026
 """
 
-from .clasificacion import accuracy, precision, recall
+from .clasificacion import accuracy, f1_score, precision, recall
 
-__all__ = ["accuracy", "precision", "recall"]
+__all__ = ["accuracy", "precision", "recall", "f1_score"]

--- a/whiteboxml/metricas/clasificacion/clasificacion.py
+++ b/whiteboxml/metricas/clasificacion/clasificacion.py
@@ -11,6 +11,7 @@ Incluye:
 - Accuracy
 - Precision
 - Recall
+- F1 Score
 
 :authors: Tomás Macrade
 :date: 28/02/2026
@@ -175,3 +176,57 @@ def recall(
     with np.errstate(divide="ignore", invalid="ignore"):
         per_class_recall = np.nan_to_num(tp / (tp + fn))
     return per_class_recall
+
+
+def f1_score(
+    y_true: ArrayLike,
+    y_pred: ArrayLike,
+    average: str | None = "binary",
+    pos_label: Any = 1,
+) -> float | np.ndarray:
+    """
+    Cálculo del F1 score.
+
+    :param y_true: targets reales
+    :param y_pred: targets predichos
+    :param average: define el tipo de average en
+    clasificación multiclase ("binary","micro", "macro", "weighted", None)
+    :param pos_label: valor a considerar como positivo
+    en el caso de targets binarios. Ignorado si average != "binary".
+    :return: score de F1 o array con el F1 por clase en caso de average = None
+    :authors: Nahuel Nicolas Alvarez
+    :date: 21/04/2026
+    """
+
+    average = _validacion_average(average)
+    vector_true, vector_pred = _validacion_inputs(y_true, y_pred)
+
+    if average == "binary":
+        tp = np.sum((vector_pred == pos_label) & (vector_true == pos_label))
+        fp = np.sum((vector_pred == pos_label) & (vector_true != pos_label))
+        fn = np.sum((vector_pred != pos_label) & (vector_true == pos_label))
+        den = 2 * tp + fp + fn
+        return float((2 * tp) / den) if den > 0 else 0.0
+
+    if average == "micro":
+        return (
+            float(np.mean(vector_true == vector_pred)) if vector_true.size > 0 else 0.0
+        )
+
+    classes = np.unique(vector_true)
+
+    components = _compute_metric_components(
+        vector_true, vector_pred, classes, ["TP", "FP", "FN"]
+    )
+    tp, fp, fn = components[:, 0], components[:, 1], components[:, 2]
+    with np.errstate(divide="ignore", invalid="ignore"):
+        per_class_f1 = np.nan_to_num((2 * tp) / (2 * tp + fp + fn))
+
+    if average == "macro":
+        return float(np.mean(per_class_f1))
+
+    if average == "weighted":
+        supports = np.array([np.sum(vector_true == c) for c in classes], dtype=float)
+        return float(np.sum(per_class_f1 * (supports / supports.sum())))
+
+    return per_class_f1

--- a/whiteboxml/reporting/__init__.py
+++ b/whiteboxml/reporting/__init__.py
@@ -6,5 +6,11 @@ Reporting: Conjunto de reportes y visualizaciones de WhiteBoxML.
 """
 
 from .reportes import classification_summary, regression_summary
+from .visualizacion import confusion_matrix, plot_confusion_matrix
 
-__all__ = ["classification_summary", "regression_summary"]
+__all__ = [
+    "classification_summary",
+    "regression_summary",
+    "confusion_matrix",
+    "plot_confusion_matrix",
+]

--- a/whiteboxml/reporting/__init__.py
+++ b/whiteboxml/reporting/__init__.py
@@ -5,6 +5,6 @@ Reporting: Conjunto de reportes y visualizaciones de WhiteBoxML.
 :date: 15/04/2026
 """
 
-from .reportes import classification_summary, regression_summary
+from .reportes import summary
 
-__all__ = ["classification_summary", "regression_summary"]
+__all__ = ["summary"]

--- a/whiteboxml/reporting/__init__.py
+++ b/whiteboxml/reporting/__init__.py
@@ -1,0 +1,10 @@
+"""
+Reporting: Conjunto de reportes y visualizaciones de WhiteBoxML.
+
+:authors: Nahuel Nicolas Alvarez
+:date: 15/04/2026
+"""
+
+from . import reportes, visualizacion
+
+__all__ = ["reportes", "visualizacion"]

--- a/whiteboxml/reporting/__init__.py
+++ b/whiteboxml/reporting/__init__.py
@@ -5,6 +5,6 @@ Reporting: Conjunto de reportes y visualizaciones de WhiteBoxML.
 :date: 15/04/2026
 """
 
-from . import reportes, visualizacion
+from .reportes import classification_summary, regression_summary
 
-__all__ = ["reportes", "visualizacion"]
+__all__ = ["classification_summary", "regression_summary"]

--- a/whiteboxml/reporting/reportes/__init__.py
+++ b/whiteboxml/reporting/reportes/__init__.py
@@ -4,3 +4,7 @@ Reportes: Módulo de reportes de WhiteBoxML.
 :authors: Nahuel Nicolas Alvarez
 :date: 15/04/2026
 """
+
+from .summary import classification_summary, regression_summary
+
+__all__ = ["classification_summary", "regression_summary"]

--- a/whiteboxml/reporting/reportes/__init__.py
+++ b/whiteboxml/reporting/reportes/__init__.py
@@ -5,6 +5,6 @@ Reportes: Módulo de reportes de WhiteBoxML.
 :date: 15/04/2026
 """
 
-from .summary import classification_summary, regression_summary
+from .summary import summary
 
-__all__ = ["classification_summary", "regression_summary"]
+__all__ = ["summary"]

--- a/whiteboxml/reporting/reportes/__init__.py
+++ b/whiteboxml/reporting/reportes/__init__.py
@@ -1,0 +1,6 @@
+"""
+Reportes: Módulo de reportes de WhiteBoxML.
+
+:authors: Nahuel Nicolas Alvarez
+:date: 15/04/2026
+"""

--- a/whiteboxml/reporting/reportes/summary.py
+++ b/whiteboxml/reporting/reportes/summary.py
@@ -8,6 +8,7 @@ Para clasificación incluye:
 - Accuracy
 - Precision
 - Recall
+- F1 Score
 
 Para regresión incluye:
 - Mean Squared Error (MSE)
@@ -39,6 +40,7 @@ def classification_summary(
     - Accuracy
     - Precision
     - Recall
+    - F1 Score
 
     :param y_true: targets reales
     :param y_pred: targets predichos
@@ -52,12 +54,14 @@ def classification_summary(
 
     precision = metricas.precision(y_true, y_pred, average=average, pos_label=pos_label)
     recall = metricas.recall(y_true, y_pred, average=average, pos_label=pos_label)
+    f1 = metricas.f1_score(y_true, y_pred, average=average, pos_label=pos_label)
 
     return pd.DataFrame(
         {
             "Accuracy": [accuracy],
             "Precision": [precision],
             "Recall": [recall],
+            "F1": [f1],
         }
     )
 

--- a/whiteboxml/reporting/reportes/summary.py
+++ b/whiteboxml/reporting/reportes/summary.py
@@ -1,0 +1,90 @@
+"""
+Reporte de métricas.
+
+Este módulo implementa la generación de reportes de métricas
+tanto de clasificación como de regresión.
+
+Para clasificación incluye:
+- Accuracy
+- Precision
+- Recall
+
+Para regresión incluye:
+- Mean Squared Error (MSE)
+- Mean Absolute Error (MAE)
+- Coeficiente de determinación (R^2)
+
+:authors: Joaquín Palacio Feijóo
+:date: 15/04/2026
+"""
+
+from typing import Any
+
+import pandas as pd
+from numpy.typing import ArrayLike
+
+from whiteboxml import metricas
+
+
+def classification_summary(
+    y_true: ArrayLike,
+    y_pred: ArrayLike,
+    average: str | None = "binary",
+    pos_label: Any = 1,
+) -> pd.DataFrame:
+    """
+    Generación de reporte de métricas de clasificación.
+
+    Incluye:
+    - Accuracy
+    - Precision
+    - Recall
+
+    :param y_true: targets reales
+    :param y_pred: targets predichos
+    :param average: tipo de promedio ("binary", "micro", "macro", "weighted", None)
+    :param pos_label: etiqueta positiva para el caso binario
+    :return: DataFrame con las métricas
+    :authors: Joaquín Palacio Feijóo
+    :date: 15/04/2026
+    """
+    accuracy = metricas.accuracy(y_true, y_pred)
+
+    precision = metricas.precision(y_true, y_pred, average=average, pos_label=pos_label)
+    recall = metricas.recall(y_true, y_pred, average=average, pos_label=pos_label)
+
+    return pd.DataFrame(
+        {
+            "Accuracy": [accuracy],
+            "Precision": [precision],
+            "Recall": [recall],
+        }
+    )
+
+
+def regression_summary(y_true: ArrayLike, y_pred: ArrayLike) -> pd.DataFrame:
+    """
+    Generación de reporte de métricas de regresión.
+
+    Incluye:
+    - Mean Squared Error (MSE)
+    - Mean Absolute Error (MAE)
+    - Coeficiente de determinación (R^2)
+
+    :param y_true: targets reales
+    :param y_pred: targets predichos
+    :return: DataFrame con las métricas
+    :authors: Joaquín Palacio Feijóo
+    :date: 15/04/2026
+    """
+    mse = metricas.mean_squared_error(y_true, y_pred)
+    mae = metricas.mean_absolute_error(y_true, y_pred)
+    r2 = metricas.r2(y_true, y_pred)
+
+    return pd.DataFrame(
+        {
+            "MSE": [mse],
+            "MAE": [mae],
+            "R^2": [r2],
+        }
+    )

--- a/whiteboxml/reporting/reportes/summary.py
+++ b/whiteboxml/reporting/reportes/summary.py
@@ -2,7 +2,8 @@
 Reporte de métricas.
 
 Este módulo implementa la generación de reportes de métricas
-tanto de clasificación como de regresión.
+tanto de clasificación como de regresión a través de una función
+unificada ``summary``.
 
 Para clasificación incluye:
 - Accuracy
@@ -15,43 +16,85 @@ Para regresión incluye:
 - Coeficiente de determinación (R^2)
 
 :authors: Joaquín Palacio Feijóo
-:date: 15/04/2026
+:date: 21/04/2026
 """
 
-from typing import Any
-
+import numpy as np
 import pandas as pd
 from numpy.typing import ArrayLike
 
 from whiteboxml import metricas
+from whiteboxml.utils import _validacion_inputs
 
 
-def classification_summary(
-    y_true: ArrayLike,
-    y_pred: ArrayLike,
-    average: str | None = "binary",
-    pos_label: Any = 1,
+def _detect_task_type(y_true: np.ndarray) -> str:
+    """
+    Detecta automáticamente si el problema es de clasificación o regresión
+    basándose en el tipo de datos de y_true.
+
+    - Strings u objetos → clasificación
+    - Booleanos → clasificación
+    - Floats con decimales → regresión
+    - Floats sin decimales / enteros → clasificación
+
+    :param y_true: targets reales (ya convertidos a np.ndarray)
+    :return: "classification" o "regression"
+    :authors: Joaquín Palacio Feijóo
+    :date: 21/04/2026
+    """
+    # Strings u objetos
+    if y_true.dtype.kind in ("U", "O"):
+        return "classification"
+
+    # Booleanos
+    if y_true.dtype.kind == "b":
+        return "classification"
+
+    # Floats
+    if y_true.dtype.kind == "f":
+        if np.all(np.isfinite(y_true)) and np.all(y_true == np.floor(y_true)):
+            return "classification"
+        return "regression"
+
+    # Enteros u otros
+    return "classification"
+
+
+def _detect_average(y_true: np.ndarray) -> str:
+    """
+    Determina el tipo de average para métricas de clasificación
+    según la cantidad de clases únicas en y_true.
+
+    - 2 clases o menos → "binary"
+    - Más de 2 clases → "macro"
+
+    :param y_true: targets reales
+    :return: "binary" o "macro"
+    :authors: Joaquín Palacio Feijóo
+    :date: 21/04/2026
+    """
+    n_classes = len(np.unique(y_true))
+    if n_classes <= 2:
+        return "binary"
+    return "macro"
+
+
+def _classification_summary(
+    y_true: np.ndarray, y_pred: np.ndarray, average: str
 ) -> pd.DataFrame:
     """
-    Generación de reporte de métricas de clasificación.
-
-    Incluye:
-    - Accuracy
-    - Precision
-    - Recall
+    Genera el reporte de métricas de clasificación.
 
     :param y_true: targets reales
     :param y_pred: targets predichos
-    :param average: tipo de promedio ("binary", "micro", "macro", "weighted", None)
-    :param pos_label: etiqueta positiva para el caso binario
-    :return: DataFrame con las métricas
+    :param average: tipo de promedio para precision y recall
+    :return: DataFrame con Accuracy, Precision y Recall
     :authors: Joaquín Palacio Feijóo
-    :date: 15/04/2026
+    :date: 21/04/2026
     """
     accuracy = metricas.accuracy(y_true, y_pred)
-
-    precision = metricas.precision(y_true, y_pred, average=average, pos_label=pos_label)
-    recall = metricas.recall(y_true, y_pred, average=average, pos_label=pos_label)
+    precision = metricas.precision(y_true, y_pred, average=average)
+    recall = metricas.recall(y_true, y_pred, average=average)
 
     return pd.DataFrame(
         {
@@ -62,20 +105,15 @@ def classification_summary(
     )
 
 
-def regression_summary(y_true: ArrayLike, y_pred: ArrayLike) -> pd.DataFrame:
+def _regression_summary(y_true: np.ndarray, y_pred: np.ndarray) -> pd.DataFrame:
     """
-    Generación de reporte de métricas de regresión.
-
-    Incluye:
-    - Mean Squared Error (MSE)
-    - Mean Absolute Error (MAE)
-    - Coeficiente de determinación (R^2)
+    Genera el reporte de métricas de regresión.
 
     :param y_true: targets reales
     :param y_pred: targets predichos
-    :return: DataFrame con las métricas
+    :return: DataFrame con MSE, MAE y R²
     :authors: Joaquín Palacio Feijóo
-    :date: 15/04/2026
+    :date: 21/04/2026
     """
     mse = metricas.mean_squared_error(y_true, y_pred)
     mae = metricas.mean_absolute_error(y_true, y_pred)
@@ -88,3 +126,42 @@ def regression_summary(y_true: ArrayLike, y_pred: ArrayLike) -> pd.DataFrame:
             "R^2": [r2],
         }
     )
+
+
+def summary(
+    y_true: ArrayLike,
+    y_pred: ArrayLike,
+    mode: str = "auto",
+) -> pd.DataFrame:
+    """
+    Generación unificada de reporte de métricas.
+
+    Detecta automáticamente si el problema es de clasificación o regresión
+    y genera el reporte correspondiente. En clasificación, determina si es
+    binaria o multiclase para seleccionar el average adecuado.
+
+    :param y_true: targets reales
+    :param y_pred: targets predichos
+    :param mode: tipo de problema ("auto", "classification", "regression").
+        Si es "auto", se detecta automáticamente.
+    :return: DataFrame con las métricas correspondientes
+    :raises ValueError: si mode no es un valor válido
+    :authors: Joaquín Palacio Feijóo
+    :date: 21/04/2026
+    """
+    valid_modes = ("auto", "classification", "regression")
+    if mode not in valid_modes:
+        raise ValueError(
+            f"El parámetro mode debe ser uno de {valid_modes}. " f'Se recibió: "{mode}"'
+        )
+
+    vector_true, vector_pred = _validacion_inputs(y_true, y_pred)
+
+    if mode == "auto":
+        mode = _detect_task_type(vector_true)
+
+    if mode == "classification":
+        average = _detect_average(vector_true)
+        return _classification_summary(vector_true, vector_pred, average)
+
+    return _regression_summary(vector_true, vector_pred)

--- a/whiteboxml/reporting/visualizacion/__init__.py
+++ b/whiteboxml/reporting/visualizacion/__init__.py
@@ -1,10 +1,21 @@
 """
 Visualización: Módulo de visualización de WhiteBoxML.
 
-:authors: Nahuel Nicolas Alvarez
-:date: 15/04/2026
+:authors: Nahuel Nicolas Alvarez, Claudio Gabriel Alonso
+:date: 21/04/2026
 """
 
 from .confusion_matrix import confusion_matrix, plot_confusion_matrix
+from .roc_pr_curves import (
+    calculate_auc,
+    calculate_roc_curve,
+    plot_roc_curve,
+)
 
-__all__ = ["confusion_matrix", "plot_confusion_matrix"]
+__all__ = [
+    "confusion_matrix",
+    "plot_confusion_matrix",
+    "calculate_auc",
+    "calculate_roc_curve",
+    "plot_roc_curve",
+]

--- a/whiteboxml/reporting/visualizacion/__init__.py
+++ b/whiteboxml/reporting/visualizacion/__init__.py
@@ -1,6 +1,6 @@
 """
-Submódulo de visualización de WhiteBoxML.
+Visualización: Módulo de visualización de WhiteBoxML.
 
-:authors: WhiteBoxML Contributors
+:authors: Nahuel Nicolas Alvarez
 :date: 15/04/2026
 """

--- a/whiteboxml/reporting/visualizacion/__init__.py
+++ b/whiteboxml/reporting/visualizacion/__init__.py
@@ -1,0 +1,6 @@
+"""
+Submódulo de visualización de WhiteBoxML.
+
+:authors: WhiteBoxML Contributors
+:date: 15/04/2026
+"""

--- a/whiteboxml/reporting/visualizacion/__init__.py
+++ b/whiteboxml/reporting/visualizacion/__init__.py
@@ -1,6 +1,6 @@
 """
 Submódulo de visualización de WhiteBoxML.
 
-:authors: WhiteBoxML Contributors
+:authors: Nahuel Nicolas Alvarez
 :date: 15/04/2026
 """

--- a/whiteboxml/reporting/visualizacion/__init__.py
+++ b/whiteboxml/reporting/visualizacion/__init__.py
@@ -4,3 +4,7 @@ Visualización: Módulo de visualización de WhiteBoxML.
 :authors: Nahuel Nicolas Alvarez
 :date: 15/04/2026
 """
+
+from .confusion_matrix import confusion_matrix, plot_confusion_matrix
+
+__all__ = ["confusion_matrix", "plot_confusion_matrix"]

--- a/whiteboxml/reporting/visualizacion/__init__.py
+++ b/whiteboxml/reporting/visualizacion/__init__.py
@@ -1,14 +1,16 @@
 """
 Visualización: Módulo de visualización de WhiteBoxML.
 
-:authors: Nahuel Nicolas Alvarez, Claudio Gabriel Alonso
+:authors: Nahuel Nicolas Alvarez, Claudio Gabriel Alonso, Fernanda Alcaraz
 :date: 21/04/2026
 """
 
 from .confusion_matrix import confusion_matrix, plot_confusion_matrix
 from .roc_pr_curves import (
     calculate_auc,
+    calculate_precision_recall_curve,
     calculate_roc_curve,
+    plot_pr_curve,
     plot_roc_curve,
 )
 
@@ -18,4 +20,6 @@ __all__ = [
     "calculate_auc",
     "calculate_roc_curve",
     "plot_roc_curve",
+    "calculate_precision_recall_curve",
+    "plot_pr_curve",
 ]

--- a/whiteboxml/reporting/visualizacion/confusion_matrix.py
+++ b/whiteboxml/reporting/visualizacion/confusion_matrix.py
@@ -5,13 +5,32 @@ Visualización: Módulo de visualización de WhiteBoxML.
 :date: 15/04/2026
 """
 
+from typing import TypedDict
+
 import matplotlib.pyplot as plt
 import numpy as np
 from matplotlib.axes import Axes
 from matplotlib.figure import Figure
+from matplotlib.gridspec import GridSpec
+from matplotlib.table import Table
 from numpy.typing import ArrayLike
 
 from whiteboxml.utils import _validacion_inputs
+
+
+class _ClassMetrics(TypedDict):
+    """
+    Estructura tipada de métricas por clase para el panel lateral.
+
+    :authors: Nahuel Nicolas Alvarez
+    :date: 29/04/2026
+    """
+
+    precision: np.ndarray
+    recall: np.ndarray
+    f1: np.ndarray
+    support: np.ndarray
+    accuracy: float
 
 
 def confusion_matrix(
@@ -49,6 +68,7 @@ def plot_confusion_matrix(
     labels: ArrayLike,
     figsize: tuple[int, int] = (6, 5),
     cmap: str = "Blues",
+    show_class_metrics: bool = True,
 ) -> tuple[Figure, Axes]:
     """
     Genera una visualización de una matriz de confusión usando Matplotlib.
@@ -56,7 +76,10 @@ def plot_confusion_matrix(
     :param cm: Matriz de confusión calculada previamente.
     :param labels: Etiquetas de las clases a mostrar en los ejes.
     :param figsize: Tamaño de la figura.
+        Si show_class_metrics es True, se usa un tamaño fijo para evitar solapamientos.
     :param cmap: Mapa de colores utilizado para el gráfico.
+    :param show_class_metrics: Si True, muestra métricas por clase
+        (precision, recall, f1 y soporte) al costado del gráfico.
     :return: Figura y ejes del gráfico generado.
 
     :authors: Nahuel Nicolas Alvarez
@@ -73,9 +96,17 @@ def plot_confusion_matrix(
             "La cantidad de labels debe coincidir con las dimensiones de la matriz."
         )
 
-    fig, ax = plt.subplots(figsize=figsize)
+    if show_class_metrics:
+        fig = plt.figure(figsize=(12, 6))
+        grid = GridSpec(1, 2, figure=fig, width_ratios=[3, 2], wspace=0.25)
+        ax = fig.add_subplot(grid[0, 0])
+        ax_metrics = fig.add_subplot(grid[0, 1])
+    else:
+        fig, ax = plt.subplots(figsize=figsize)
+
     image = ax.imshow(cm, interpolation="nearest", cmap=cmap)
-    fig.colorbar(image, ax=ax)
+    cbar = fig.colorbar(image, ax=ax, fraction=0.046, pad=0.04)
+    cbar.set_label("Cantidad de observaciones", rotation=90)
 
     ax.set(
         xticks=np.arange(len(labels)),
@@ -86,9 +117,30 @@ def plot_confusion_matrix(
         ylabel="Valor real",
         title="Matriz de confusión",
     )
+    ax.grid(False)
 
     plt.setp(ax.get_xticklabels(), rotation=45, ha="right", rotation_mode="anchor")
 
+    _annotate_confusion_matrix(ax, cm)
+
+    if show_class_metrics:
+        metrics = _compute_class_metrics(cm)
+        _draw_metrics_table(ax_metrics, labels, metrics)
+
+    fig.tight_layout()
+    return fig, ax
+
+
+def _annotate_confusion_matrix(ax: Axes, cm: np.ndarray) -> None:
+    """
+    Agrega anotaciones de conteo sobre cada celda de la matriz.
+
+    :param ax: Ejes donde se dibuja la matriz.
+    :param cm: Matriz de confusión.
+    :return: None.
+    :authors: Nahuel Nicolas Alvarez
+    :date: 29/04/2026
+    """
     threshold = cm.max() / 2 if cm.size > 0 else 0
     for i in range(cm.shape[0]):
         for j in range(cm.shape[1]):
@@ -98,8 +150,131 @@ def plot_confusion_matrix(
                 str(cm[i, j]),
                 ha="center",
                 va="center",
-                color="white" if cm[i, j] > threshold else "black",
+                color="white" if cm[i, j] > threshold else "#1f2937",
+                fontsize=10,
+                fontweight="bold" if i == j else "normal",
             )
 
-    fig.tight_layout()
-    return fig, ax
+
+def _compute_class_metrics(cm: np.ndarray) -> _ClassMetrics:
+    """
+    Calcula métricas por clase a partir de la matriz de confusión.
+
+    :param cm: Matriz de confusión.
+    :return: Diccionario con precision, recall, f1, support y accuracy.
+    :authors: Nahuel Nicolas Alvarez
+    :date: 29/04/2026
+    """
+    tp = np.diag(cm).astype(float)
+    predicted = cm.sum(axis=0).astype(float)
+    actual = cm.sum(axis=1).astype(float)
+    total = float(cm.sum())
+
+    with np.errstate(divide="ignore", invalid="ignore"):
+        precision = np.nan_to_num(tp / predicted)
+        recall = np.nan_to_num(tp / actual)
+        f1 = np.nan_to_num((2 * precision * recall) / (precision + recall))
+        accuracy = np.nan_to_num(tp.sum() / total) if total > 0 else 0.0
+
+    return {
+        "precision": precision,
+        "recall": recall,
+        "f1": f1,
+        "support": actual,
+        "accuracy": float(accuracy),
+    }
+
+
+def _build_metrics_rows(
+    labels: np.ndarray,
+    metrics: _ClassMetrics,
+    decimals: int = 3,
+) -> list[list[str]]:
+    """
+    Construye las filas de texto para la tabla de métricas por clase.
+
+    :param labels: Etiquetas de clase.
+    :param metrics: Diccionario tipado con métricas por clase.
+    :param decimals: Cantidad de decimales a mostrar.
+    :return: Filas de texto para la tabla.
+    :authors: Nahuel Nicolas Alvarez
+    :date: 29/04/2026
+    """
+    return [
+        [
+            str(cls),
+            f"{p_i:.{decimals}f}",
+            f"{r_i:.{decimals}f}",
+            f"{f_i:.{decimals}f}",
+            str(int(s_i)),
+        ]
+        for cls, p_i, r_i, f_i, s_i in zip(
+            labels,
+            metrics["precision"],
+            metrics["recall"],
+            metrics["f1"],
+            metrics["support"],
+        )
+    ]
+
+
+def _style_metrics_table(table: Table) -> None:
+    """
+    Aplica estilo visual al encabezado y filas de la tabla de métricas.
+
+    :param table: Tabla de Matplotlib a estilizar.
+    :return: None.
+    :authors: Nahuel Nicolas Alvarez
+    :date: 29/04/2026
+    """
+    header_color = "#1e3a8a"
+    row_light = "#dbeafe"
+    row_white = "#eff6ff"
+
+    for (row, col), cell in table.get_celld().items():
+        if row == 0:
+            cell.set_facecolor(header_color)
+            cell.get_text().set_color("white")
+            cell.get_text().set_weight("bold")
+        else:
+            cell.set_facecolor(row_light if row % 2 else row_white)
+
+    for col in range(5):
+        table[(0, col)].set_edgecolor("white")
+
+
+def _draw_metrics_table(
+    ax: Axes,
+    labels: np.ndarray,
+    metrics: _ClassMetrics,
+    decimals: int = 3,
+) -> None:
+    """
+    Dibuja una tabla de métricas por clase en un panel lateral.
+
+    :param ax: Ejes donde se dibuja la tabla.
+    :param labels: Etiquetas de clase.
+    :param metrics: Diccionario con métricas por clase y accuracy global.
+    :param decimals: Cantidad de decimales a mostrar.
+    :return: None.
+    :authors: Nahuel Nicolas Alvarez
+    :date: 29/04/2026
+    """
+    accuracy = metrics["accuracy"]
+
+    ax.axis("off")
+    ax.set_title(f"Metricas por clase (Accuracy: {accuracy:.{decimals}f})", fontsize=10)
+
+    row_data = _build_metrics_rows(labels, metrics, decimals)
+
+    table = ax.table(
+        cellText=row_data,
+        colLabels=["Clase", "Precision", "Recall", "F1", "Soporte"],
+        cellLoc="center",
+        loc="center",
+    )
+    table.auto_set_font_size(False)
+    table.set_fontsize(9)
+    table.scale(1.0, 1.4)
+
+    _style_metrics_table(table)

--- a/whiteboxml/reporting/visualizacion/confusion_matrix.py
+++ b/whiteboxml/reporting/visualizacion/confusion_matrix.py
@@ -1,0 +1,105 @@
+"""
+Visualización: Módulo de visualización de WhiteBoxML.
+
+:authors: Nahuel Nicolas Alvarez
+:date: 15/04/2026
+"""
+
+import matplotlib.pyplot as plt
+import numpy as np
+from matplotlib.axes import Axes
+from matplotlib.figure import Figure
+from numpy.typing import ArrayLike
+
+from whiteboxml.utils import _validacion_inputs
+
+
+def confusion_matrix(
+    y_true: ArrayLike, y_pred: ArrayLike, labels: ArrayLike | None = None
+) -> np.ndarray:
+    """
+    Genera una matriz de confusión a partir de los valores reales y predichos.
+
+    Las filas representan las clases reales y las columnas las clases predichas.
+
+    :param y_true: Array de valores reales.
+    :param y_pred: Array de valores predichos.
+    :param labels: Lista de etiquetas para las clases.
+        Si es None, se inferirán de los datos.
+    :return: Matriz de confusión como un array de NumPy.
+
+    :authors: Nahuel Nicolas Alvarez
+    :date: 19/04/2026
+    """
+    y_true, y_pred = _validacion_inputs(y_true, y_pred)
+
+    if labels is None:
+        labels = np.unique(np.concatenate((y_true, y_pred)))
+    else:
+        labels = np.asarray(labels)
+
+    return np.array(
+        [[np.sum((y_true == i) & (y_pred == j)) for j in labels] for i in labels],
+        dtype=int,
+    )
+
+
+def plot_confusion_matrix(
+    cm: np.ndarray,
+    labels: ArrayLike,
+    figsize: tuple[int, int] = (6, 5),
+    cmap: str = "Blues",
+) -> tuple[Figure, Axes]:
+    """
+    Genera una visualización de una matriz de confusión usando Matplotlib.
+
+    :param cm: Matriz de confusión calculada previamente.
+    :param labels: Etiquetas de las clases a mostrar en los ejes.
+    :param figsize: Tamaño de la figura.
+    :param cmap: Mapa de colores utilizado para el gráfico.
+    :return: Figura y ejes del gráfico generado.
+
+    :authors: Nahuel Nicolas Alvarez
+    :date: 19/04/2026
+    """
+    cm = np.asarray(cm)
+    labels = np.asarray(labels)
+
+    if cm.ndim != 2 or cm.shape[0] != cm.shape[1]:
+        raise ValueError("cm debe ser una matriz cuadrada de dos dimensiones.")
+
+    if cm.shape[0] != len(labels):
+        raise ValueError(
+            "La cantidad de labels debe coincidir con las dimensiones de la matriz."
+        )
+
+    fig, ax = plt.subplots(figsize=figsize)
+    image = ax.imshow(cm, interpolation="nearest", cmap=cmap)
+    fig.colorbar(image, ax=ax)
+
+    ax.set(
+        xticks=np.arange(len(labels)),
+        yticks=np.arange(len(labels)),
+        xticklabels=labels,
+        yticklabels=labels,
+        xlabel="Predicción",
+        ylabel="Valor real",
+        title="Matriz de confusión",
+    )
+
+    plt.setp(ax.get_xticklabels(), rotation=45, ha="right", rotation_mode="anchor")
+
+    threshold = cm.max() / 2 if cm.size > 0 else 0
+    for i in range(cm.shape[0]):
+        for j in range(cm.shape[1]):
+            ax.text(
+                j,
+                i,
+                str(cm[i, j]),
+                ha="center",
+                va="center",
+                color="white" if cm[i, j] > threshold else "black",
+            )
+
+    fig.tight_layout()
+    return fig, ax

--- a/whiteboxml/reporting/visualizacion/roc_pr_curves.py
+++ b/whiteboxml/reporting/visualizacion/roc_pr_curves.py
@@ -5,6 +5,8 @@ Módulo para cálculo y visualización de curvas ROC.
 :date: 21/04/2026
 """
 
+from typing import Optional, Tuple
+
 import matplotlib.pyplot as plt
 import numpy as np
 from numpy.typing import ArrayLike
@@ -66,32 +68,40 @@ def calculate_roc_curve(
 
 
 def plot_roc_curve(
-    y_true: ArrayLike, y_pred_proba: ArrayLike, show_diagonal: bool = True
-) -> None:
+    y_true: ArrayLike,
+    y_pred_proba: ArrayLike,
+    show_diagonal: bool = True,
+    show: bool = True,
+) -> Optional[Tuple[plt.Figure, plt.Axes]]:
     """
     Calcula y grafica la curva ROC a partir de los datos de entrada.
 
     :param y_true: Array de etiquetas reales (0 o 1).
     :param y_pred_proba: Array de probabilidades estimadas.
     :param show_diagonal: Si True, muestra la línea base.
-    :return: None.
+    :param show: Si True, muestra el gráfico. Si False, devuelve la figura.
+    :return: fig, ax si show=False, caso contrario None.
 
     :authors: Claudio Gabriel Alonso
-    :date: 20/04/2026
+    :date: 29/04/2026
     """
 
     fpr, tpr, _ = calculate_roc_curve(y_true, y_pred_proba)
     auc = calculate_auc(fpr, tpr)
 
-    plt.figure()
-    plt.plot(fpr, tpr, label=f"AUC = {auc:.4f}")
+    fig, ax = plt.subplots()
+    ax.plot(fpr, tpr, label=f"AUC = {auc:.4f}")
 
     if show_diagonal:
-        plt.plot([0, 1], [0, 1], linestyle="--")
+        ax.plot([0, 1], [0, 1], linestyle="--")
 
-    plt.xlabel("False Positive Rate")
-    plt.ylabel("True Positive Rate")
-    plt.title("ROC Curve")
-    plt.legend()
-    plt.grid()
-    plt.show()
+    ax.set_xlabel("False Positive Rate")
+    ax.set_ylabel("True Positive Rate")
+    ax.set_title("ROC Curve")
+    ax.legend()
+    ax.grid()
+
+    if show:
+        plt.show()
+        return None
+    return fig, ax

--- a/whiteboxml/reporting/visualizacion/roc_pr_curves.py
+++ b/whiteboxml/reporting/visualizacion/roc_pr_curves.py
@@ -20,7 +20,7 @@ def calculate_auc(fpr: ArrayLike, tpr: ArrayLike) -> float:
     :param tpr: True Positive Rate.
     :return: Valor del AUC.
 
-    :authors: Claudio Gabriel Alonso
+    :authors: Claudio Gabriel Alonso, Fernanda Alcaraz
     :date: 20/04/2026
     """
 
@@ -99,6 +99,95 @@ def plot_roc_curve(
     ax.set_ylabel("True Positive Rate")
     ax.set_title("ROC Curve")
     ax.legend()
+    ax.grid()
+
+    if show:
+        plt.show()
+        return None
+    return fig, ax
+
+
+def calculate_precision_recall_curve(y_true, y_pred_proba):
+    """
+    Calcular la curva de Precision-Recall.
+
+    :param y_true: Array de etiquetas reales (0 o 1).
+    :param y_pred_proba: Array de probabilidades estimadas.
+    :return: Tupla (recall, precision, thresholds).
+
+    :authors: Fernanda Alcaraz
+    :date: 09/05/2026
+    """
+
+    y_true = np.asarray(y_true)
+    y_pred_proba = np.asarray(y_pred_proba)
+
+    thresholds = sorted(
+        set(y_pred_proba),
+        reverse=True,
+    )
+
+    precision = [1.0]
+    recall = [0.0]
+
+    positives = sum(y_true)
+
+    for threshold in thresholds:
+        y_pred = [1 if p >= threshold else 0 for p in y_pred_proba]
+
+        tp = sum(
+            yt == 1 and yp == 1
+            for yt, yp in zip(
+                y_true,
+                y_pred,
+            )
+        )
+
+        fp = sum(
+            yt == 0 and yp == 1
+            for yt, yp in zip(
+                y_true,
+                y_pred,
+            )
+        )
+
+        if tp + fp > 0:
+            prec = tp / (tp + fp)
+        else:
+            prec = 1.0
+
+        rec = tp / positives
+
+        precision.append(prec)
+        recall.append(rec)
+
+    return recall, precision, thresholds
+
+
+def plot_pr_curve(
+    y_true: ArrayLike,
+    y_pred_proba: ArrayLike,
+    show: bool = True,
+) -> Optional[Tuple[plt.Figure, plt.Axes]]:
+    """
+    Calcula y grafica la curva PR a partir de los datos de entrada.
+
+    :param y_true: Array de etiquetas reales (0 o 1).
+    :param y_pred_proba: Array de probabilidades estimadas.
+    :param show: Si True, muestra el gráfico. Si False, devuelve la figura.
+    :return: fig, ax si show=False, caso contrario None.
+
+    :authors: Fernanda Alcaraz
+    :date: 09/05/2026
+    """
+
+    recall, precision, _ = calculate_precision_recall_curve(y_true, y_pred_proba)
+
+    fig, ax = plt.subplots()
+    ax.plot(recall, precision)
+    ax.set_xlabel("Recall")
+    ax.set_ylabel("Precision")
+    ax.set_title("Precision-Recall Curve")
     ax.grid()
 
     if show:

--- a/whiteboxml/reporting/visualizacion/roc_pr_curves.py
+++ b/whiteboxml/reporting/visualizacion/roc_pr_curves.py
@@ -1,0 +1,97 @@
+"""
+Módulo para cálculo y visualización de curvas ROC.
+
+:authors: Claudio Gabriel Alonso
+:date: 21/04/2026
+"""
+
+import matplotlib.pyplot as plt
+import numpy as np
+from numpy.typing import ArrayLike
+
+
+def calculate_auc(fpr: ArrayLike, tpr: ArrayLike) -> float:
+    """
+    Calcula el área bajo la curva ROC (AUC) usando integración numérica.
+
+    :param fpr: False Positive Rate.
+    :param tpr: True Positive Rate.
+    :return: Valor del AUC.
+
+    :authors: Claudio Gabriel Alonso
+    :date: 20/04/2026
+    """
+
+    fpr = np.asarray(fpr)
+    tpr = np.asarray(tpr)
+
+    return np.trapz(tpr, fpr)
+
+
+def calculate_roc_curve(
+    y_true: ArrayLike, y_pred_proba: ArrayLike
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """
+    Calcula la curva ROC a partir de etiquetas reales y probabilidades predichas.
+
+    :param y_true: Array de etiquetas reales (0 o 1).
+    :param y_pred_proba: Array de probabilidades estimadas para la clase positiva.
+    :return: Tupla (fpr, tpr, thresholds).
+
+    :authors: Claudio Gabriel Alonso
+    :date: 20/04/2026
+    """
+
+    y_true = np.asarray(y_true)
+    y_pred_proba = np.asarray(y_pred_proba)
+
+    sorted_indices = np.argsort(y_pred_proba)[::-1]
+    y_true_sorted = y_true[sorted_indices]
+    thresholds = y_pred_proba[sorted_indices]
+
+    tp = np.cumsum(y_true_sorted)
+    fp = np.cumsum(1 - y_true_sorted)
+
+    n_pos = np.sum(y_true)
+    n_neg = np.sum(1 - y_true)
+
+    tpr = tp / n_pos if n_pos > 0 else np.zeros_like(tp)
+    fpr = fp / n_neg if n_neg > 0 else np.zeros_like(fp)
+
+    tpr = np.concatenate(([0.0], tpr))
+    fpr = np.concatenate(([0.0], fpr))
+    thresholds = np.concatenate(([1.0], thresholds))
+
+    return fpr, tpr, thresholds
+
+
+def plot_roc_curve(
+    y_true: ArrayLike, y_pred_proba: ArrayLike, show_diagonal: bool = True
+) -> None:
+    """
+    Calcula y grafica la curva ROC a partir de los datos de entrada.
+
+    :param y_true: Array de etiquetas reales (0 o 1).
+    :param y_pred_proba: Array de probabilidades estimadas.
+    :param show_diagonal: Si True, muestra la línea base.
+    :return: None.
+
+    :authors: Claudio Gabriel Alonso
+    :date: 20/04/2026
+    """
+
+    fpr, tpr, _ = calculate_roc_curve(y_true, y_pred_proba)
+    auc = calculate_auc(fpr, tpr)
+
+    plt.figure()
+    plt.plot(fpr, tpr, label=f"AUC = {auc:.4f}")
+
+    if show_diagonal:
+        plt.plot([0, 1], [0, 1], linestyle="--")
+
+    plt.xlabel("False Positive Rate")
+    plt.ylabel("True Positive Rate")
+    plt.title("ROC Curve")
+    plt.legend()
+    plt.grid()
+    plt.show()


### PR DESCRIPTION
Agregamos un primer módulo de reporting y visualización. Se implementó un primer gráfico de **matriz de confusión** y de **f1 score**. También se sumó una función de **summary** que devuelve metricas de un modelo, para detectar que metricas devolver detecta automaticamente segun los valores de los 'y' recibidos si es un modelo de regresión o de clasificación, en caso de que sea de clasificación detecta si es binario o multiclase.
Ambos añadidos tienen sus respectivos test.

Como proximos pasos, la idea es mejorar la presentación de la matriz de confusión y como se muestran sus métricas. Además de sumar la Curva ROC/PR que está en proceso de testeo